### PR TITLE
Makes same footer for learning and authoring

### DIFF
--- a/src/components/studio-footer/StudioFooter.jsx
+++ b/src/components/studio-footer/StudioFooter.jsx
@@ -1,24 +1,17 @@
 import React, { useContext } from 'react';
-import isEmpty from 'lodash/isEmpty';
-import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { ensureConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
-  ActionRow,
   Container,
-  Hyperlink,
 } from '@openedx/paragon';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import '../../_footer.scss';
 
-// import messages from './messages';
 import messages from '../Footer.messages';
 import LanguageSelector from '../LanguageSelector';
-
-import StudioFooterLogoSlot from '../../plugin-slots/StudioFooterLogoSlot';
 import StudioFooterHelpSectionSlot from '../../plugin-slots/StudioFooterHelpSectionSlot';
 
 ensureConfig([
@@ -62,87 +55,47 @@ const StudioFooter = ({
   return (
     <>
       <StudioFooterHelpSectionSlot containerProps={containerProps} />
-          <footer
-      role="contentinfo"
-      className="footer wrapper-footer"
-    >
-      <div className="footer-container">
-        <nav className="nav-colophon">
-          <ol>
-            {indigoFooterNavLinks.map((link) => (
-              <li key={link.url}>
-                <a
-                  href={`${link.url.includes('http') ? '' : config.LMS_BASE_URL}${link.url}`}
-                  target={link.url.includes('http') ? '_blank' : undefined}
-                  rel={link.url.includes('http') ? 'noopener noreferrer' : undefined}
-                >
-                  {link.title}
-                </a>
-              </li>
-            ))}
-          </ol>
-        </nav>
-        <a
-          className="d-block"
-          href={config.LMS_BASE_URL}
-          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
-          onClick={externalLinkClickHandler}
-        >
-          <img
-            style={{ maxWidth: 163 }}
-            src={logo || config.LOGO_TRADEMARK_URL}
-            alt={intl.formatMessage(messages['footer.logo.altText'])}
-          />
-        </a>
-        {showLanguageSelector && (
-          <LanguageSelector
-            options={allowedLanguages}
-            onSubmit={onLanguageSelected}
-          />
-        )}
-      </div>
-    </footer>
-
-      {/* <Container
-        size="xl"
-        className={classNames('px-4', containerClassName)}
-        {...restContainerProps}
+      <footer
+        role="contentinfo"
+        className="footer wrapper-footer"
       >
-        <ActionRow className="pt-3 m-0 x-small">
-          © {new Date().getFullYear()} <Hyperlink destination={config.MARKETING_SITE_BASE_URL} target="_blank" className="ml-2">{config.SITE_NAME}</Hyperlink>
-          <ActionRow.Spacer />
-          {!isEmpty(config.TERMS_OF_SERVICE_URL) && (
-            <Hyperlink destination={config.TERMS_OF_SERVICE_URL} data-testid="termsOfService">
-              {intl.formatMessage(messages.termsOfServiceLinkLabel)}
-            </Hyperlink>
-          )}{!isEmpty(config.PRIVACY_POLICY_URL) && (
-            <Hyperlink destination={config.PRIVACY_POLICY_URL} data-testid="privacyPolicy">
-              {intl.formatMessage(messages.privacyPolicyLinkLabel)}
-            </Hyperlink>
+        <div className="footer-container">
+          <nav className="nav-colophon">
+            <ol>
+              {indigoFooterNavLinks.map((link) => (
+                <li key={link.url}>
+                  <a
+                    href={`${link.url.includes('http') ? '' : config.LMS_BASE_URL}${link.url}`}
+                    target={link.url.includes('http') ? '_blank' : undefined}
+                    rel={link.url.includes('http') ? 'noopener noreferrer' : undefined}
+                  >
+                    {link.title}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+          <a
+            className="d-block"
+            href={config.LMS_BASE_URL}
+            aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+            onClick={externalLinkClickHandler}
+          >
+            <img
+              style={{ maxWidth: 163 }}
+              src={logo || config.LOGO_TRADEMARK_URL}
+              alt={intl.formatMessage(messages['footer.logo.altText'])}
+            />
+          </a>
+
+          {showLanguageSelector && (
+            <LanguageSelector
+              options={allowedLanguages}
+              onSubmit={onLanguageSelected}
+            />
           )}
-          {config.ENABLE_ACCESSIBILITY_PAGE === 'true' && (
-            <Hyperlink
-              destination={`${config.STUDIO_BASE_URL}/accessibility`}
-              data-testid="accessibilityRequest"
-            >
-              {intl.formatMessage(messages.accessibilityRequestLinkLabel)}
-            </Hyperlink>
-          )}
-          <Hyperlink destination={config.LMS_BASE_URL}>LMS</Hyperlink>
-        </ActionRow>
-        <ActionRow className="mt-3 pb-4 x-small">
-          {/*
-            Site operators: Please do not remove this paragraph! this attributes back to edX and
-              makes your acknowledgement of edX's trademarks clear.
-            Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate
-              any of these trademarks and company names.
-          */}
-          {/* <FormattedMessage {...messages.trademarkMessage} />
-          <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
-          <ActionRow.Spacer />
-          <StudioFooterLogoSlot />
-        </ActionRow>
-      </Container> */}
+        </div>
+      </footer>
     </>
   );
 };

--- a/src/components/studio-footer/StudioFooter.jsx
+++ b/src/components/studio-footer/StudioFooter.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { ensureConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
 import {
@@ -11,7 +12,12 @@ import {
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import messages from './messages';
+import '../../_footer.scss';
+
+// import messages from './messages';
+import messages from '../Footer.messages';
+import LanguageSelector from '../LanguageSelector';
+
 import StudioFooterLogoSlot from '../../plugin-slots/StudioFooterLogoSlot';
 import StudioFooterHelpSectionSlot from '../../plugin-slots/StudioFooterHelpSectionSlot';
 
@@ -24,20 +30,80 @@ ensureConfig([
   'SITE_NAME',
   'STUDIO_BASE_URL',
   'ENABLE_ACCESSIBILITY_PAGE',
+  'INDIGO_FOOTER_NAV_LINKS'
 ], 'Studio Footer component');
 
 const StudioFooter = ({
   containerProps,
+  supportedLanguages,
+  onLanguageSelected,
+  logo,
 }) => {
   const intl = useIntl();
   const { config } = useContext(AppContext);
 
   const { containerClassName, ...restContainerProps } = containerProps || {};
+  const indigoFooterNavLinks = config.INDIGO_FOOTER_NAV_LINKS || [];
+  const allowedLanguages = supportedLanguages || [];
+  const showLanguageSelector = allowedLanguages.length > 0 && onLanguageSelected;
+
+
+    const externalLinkClickHandler = (event) => {
+      const label = event.currentTarget.getAttribute('href');
+      const eventName = EVENT_NAMES.FOOTER_LINK;
+      const properties = {
+        category: 'outbound_link',
+        label,
+      };
+      sendTrackEvent(eventName, properties);
+    };
+
 
   return (
     <>
       <StudioFooterHelpSectionSlot containerProps={containerProps} />
-      <Container
+          <footer
+      role="contentinfo"
+      className="footer wrapper-footer"
+    >
+      <div className="footer-container">
+        <nav className="nav-colophon">
+          <ol>
+            {indigoFooterNavLinks.map((link) => (
+              <li key={link.url}>
+                <a
+                  href={`${link.url.includes('http') ? '' : config.LMS_BASE_URL}${link.url}`}
+                  target={link.url.includes('http') ? '_blank' : undefined}
+                  rel={link.url.includes('http') ? 'noopener noreferrer' : undefined}
+                >
+                  {link.title}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+        <a
+          className="d-block"
+          href={config.LMS_BASE_URL}
+          aria-label={intl.formatMessage(messages['footer.logo.ariaLabel'])}
+          onClick={externalLinkClickHandler}
+        >
+          <img
+            style={{ maxWidth: 163 }}
+            src={logo || config.LOGO_TRADEMARK_URL}
+            alt={intl.formatMessage(messages['footer.logo.altText'])}
+          />
+        </a>
+        {showLanguageSelector && (
+          <LanguageSelector
+            options={allowedLanguages}
+            onSubmit={onLanguageSelected}
+          />
+        )}
+      </div>
+    </footer>
+
+      {/* <Container
         size="xl"
         className={classNames('px-4', containerClassName)}
         {...restContainerProps}
@@ -71,12 +137,12 @@ const StudioFooter = ({
             Translators: 'edX' and 'Open edX' are trademarks of 'edX Inc.'. Please do not translate
               any of these trademarks and company names.
           */}
-          <FormattedMessage {...messages.trademarkMessage} />
+          {/* <FormattedMessage {...messages.trademarkMessage} />
           <Hyperlink className="ml-1" destination="https://www.edx.org">edX Inc</Hyperlink>.
           <ActionRow.Spacer />
           <StudioFooterLogoSlot />
         </ActionRow>
-      </Container>
+      </Container> */}
     </>
   );
 };

--- a/src/components/studio-footer/index.jsx
+++ b/src/components/studio-footer/index.jsx
@@ -1,3 +1,4 @@
-import StudioFooter from './StudioFooter';
+import '../../_footer.scss';
+import StudioFooter from '../Footer';
 
 export default StudioFooter;

--- a/src/components/studio-footer/index.jsx
+++ b/src/components/studio-footer/index.jsx
@@ -1,4 +1,3 @@
-import '../../_footer.scss';
-import StudioFooter from '../Footer';
+import StudioFooter from './StudioFooter';
 
 export default StudioFooter;


### PR DESCRIPTION
## Description
This PR updates the footer to ensure it is consistent across both the **Learning** and **Authoring** experiences.  
Previously, the two experiences used different footer structures and content, which could cause inconsistency in navigation and branding.  

With this update:
- The same footer layout and links are applied to both areas  
- Styling and structure are unified for consistency  

| Before | After |
| -- | -- | 
| <img width="3022" height="1526" alt="image" src="https://github.com/user-attachments/assets/1c7344dc-df4b-4990-85f7-7bed9a9fb060" /> | <img width="3022" height="1528" alt="image" src="https://github.com/user-attachments/assets/affa78b5-e53b-4335-b32f-3c7b944ced19" /> |
