### PR TITLE
feat: Make LMS header consistent with Wikilearn

### DIFF
--- a/src/_footer.scss
+++ b/src/_footer.scss
@@ -131,6 +131,9 @@ footer.wrapper-footer {
   }
 }
 
+/* --------------------- HEADER STYLES --------------------- */
+
+/* *** Header logo dark theme style *** */
 .indigo-dark-theme {
 
   .footer-container {
@@ -145,5 +148,26 @@ footer.wrapper-footer {
         filter: invert(1);
       }
     }
+  }
+}
+
+/* *** Header navigation style *** */
+header {
+  &.learning-header {
+    .course-title-lockup {
+      .nav-course {
+        &:nth-of-type(2) {
+          margin-left: auto;
+        }
+        &:last-of-type {
+          margin-right: auto;
+        }
+      }
+    }
+  }
+
+  .main-nav {
+    flex-grow: 1;
+    align-items: center;
   }
 }


### PR DESCRIPTION
### Make LMS header consistent with Wikilearn

| | |
| -- | -- |
| <img width="3022" height="1382" alt="image" src="https://github.com/user-attachments/assets/c70c38ef-8398-43e4-a6c3-c7e518769173" /> | <img width="3022" height="1418" alt="image" src="https://github.com/user-attachments/assets/77cc15a4-e960-4f9c-bc6a-8300274d056d" />  |
